### PR TITLE
feat: Implement speech-to-text for contact notes

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <!-- OPTIONAL PERMISSIONS, REMOVE WHATEVER YOU DO NOT NEED -->
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>

--- a/ios/DropCard/Info.plist
+++ b/ios/DropCard/Info.plist
@@ -53,7 +53,9 @@
     <key>NSCameraUsageDescription</key>
     <string>The app accesses your camera to let you take photos for your business card.</string>
     <key>NSMicrophoneUsageDescription</key>
-    <string>Allow $(PRODUCT_NAME) to access your microphone</string>
+    <string>This app needs access to your microphone to record voice notes and convert them to text.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>This app uses speech recognition to convert your voice into text for notes.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>The app accesses your photos to let you share them with your business card.</string>
     <key>UILaunchStoryboardName</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/metro-runtime": "~5.0.4",
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "^2.1.2",
+        "@react-native-community/voice": "^1.1.9",
         "@react-navigation/bottom-tabs": "^7.3.13",
         "@react-navigation/native": "^7.1.9",
         "@react-navigation/stack": "^7.3.2",
@@ -2329,6 +2330,17 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/voice": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@react-native-community/voice/-/voice-1.1.9.tgz",
+      "integrity": "sha512-6QC51lIxdtPyIWyJEG7qsZ0nyRQFV7wUREcnvlQD3+xyk3p5na9LELR+rkIGdxVbLb3WJ73rhgjrc/ywyUh10Q==",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.40.0"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@expo/metro-runtime": "~5.0.4",
     "@expo/vector-icons": "^14.1.0",
     "@react-native-async-storage/async-storage": "^2.1.2",
+    "@react-native-community/voice": "^1.1.9",
     "@react-navigation/bottom-tabs": "^7.3.13",
     "@react-navigation/native": "^7.1.9",
     "@react-navigation/stack": "^7.3.2",


### PR DESCRIPTION
Integrates speech-to-text functionality into the Add Contact screen, allowing you to dictate notes using the microphone.

Key changes:
- Added `@react-native-community/voice` library for speech recognition.
- Replaced the previous "Add Voice Note" button with a "Start/Stop Dictation" button.
- Implemented logic to capture spoken words and append them to the notes text input field.
- Configured necessary permissions for microphone and speech recognition on iOS and Android.
- Updated state management in AddContactScreen to handle the dictation process, including listening state, results, and errors.

Testing procedures have been outlined to verify functionality on devices/simulators.