### PR TITLE
feat: Save new contacts to Supabase

### DIFF
--- a/src/screens/AddContactScreen.js
+++ b/src/screens/AddContactScreen.js
@@ -10,8 +10,11 @@ import {
   Alert,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { supabase } from '../lib/supabase'; // Import supabase
+import { useAuth } from '../context/AuthContext'; // Import useAuth
 
 export default function AddContactScreen({ navigation }) {
+  const { user } = useAuth(); // Get user from useAuth
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -36,14 +39,35 @@ export default function AddContactScreen({ navigation }) {
     }
   };
 
-  const handleSave = () => {
+  const handleSave = async () => { // Make handleSave async
     if (!formData.name.trim()) {
       Alert.alert('Error', 'Please enter a name');
       return;
     }
 
-    Alert.alert('Success', 'Contact saved successfully!');
-    navigation.goBack();
+    try {
+      const { data, error } = await supabase
+        .from('contacts')
+        .insert([
+          {
+            name: formData.name,
+            email: formData.email,
+            notes: formData.notes,
+            user_id: user.id, // Add user_id
+          },
+        ])
+        .select();
+
+      if (error) {
+        Alert.alert('Error', 'Failed to save contact: ' + error.message);
+        return;
+      }
+
+      Alert.alert('Success', 'Contact saved successfully!');
+      navigation.goBack();
+    } catch (error) {
+      Alert.alert('Error', 'An unexpected error occurred: ' + error.message);
+    }
   };
 
   return (


### PR DESCRIPTION
This commit implements the functionality to save new contacts to Supabase when added manually through the Contacts screen.

The following changes were made:

- Modified `AddContactScreen.js` to:
    - Import the `supabase` client and `useAuth` hook.
    - Get the current user's ID.
    - In the `handleSave` function, construct a contact object with name, email, notes, and user ID.
    - Use `supabase.from('contacts').insert()` to save the contact to the 'contacts' table.
    - Display appropriate success or error messages to you.